### PR TITLE
chore: eslint added for js/ts/vue files via trunk cli config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .hermit/node/lib/node_modules/*
 .hermit/node/cache/*
 server/static
+!.trunk

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,8 @@
+*out
+*logs
+*actions
+*notifications
+plugins
+user_trunk.yaml
+user.yaml
+shims

--- a/.trunk/configs/.hadolint.yaml
+++ b/.trunk/configs/.hadolint.yaml
@@ -1,0 +1,4 @@
+# Following source doesn't work in most setups
+ignored:
+  - SC1090
+  - SC1091

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,10 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false

--- a/.trunk/configs/.shellcheckrc
+++ b/.trunk/configs/.shellcheckrc
@@ -1,0 +1,7 @@
+enable=all
+source-path=SCRIPTDIR
+disable=SC2154
+
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,10 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,41 @@
+version: 0.1
+cli:
+  version: 1.8.1
+plugins:
+  sources:
+    - id: trunk
+      ref: v0.0.16
+      uri: https://github.com/trunk-io/plugins
+lint:
+  files:
+    - name: vue
+      extensions: [vue]
+      comments: [html-tag]
+  definitions:
+    - name: eslint
+      files: [typescript, javascript, vue]
+  enabled:
+    - eslint@8.39.0:
+        packages:
+          - eslint-plugin-vue@9.11.0
+          - '@typescript-eslint/parser@5.59.2'
+  disabled:
+    - actionlint
+    - git-diff-check
+    - gitleaks
+    - gofmt
+    - golangci-lint
+    - hadolint
+    - markdownlint
+    - prettier
+    - shellcheck
+    - shfmt
+    - yamllint
+runtimes:
+  enabled:
+    - node@18.12.1
+actions:
+  enabled:
+    - git-blame-ignore-revs
+    - trunk-cache-prune
+    - trunk-upgrade-available

--- a/frontend/.eslintrc.yml
+++ b/frontend/.eslintrc.yml
@@ -1,0 +1,13 @@
+env:
+  browser: true
+  es2021: true
+extends:
+  - eslint:recommended
+  - plugin:vue/vue3-recommended
+overrides: []
+parser: vue-eslint-parser
+parserOptions:
+  parser: "@typescript-eslint/parser"
+  ecmaVersion: latest
+  sourceType: module
+


### PR DESCRIPTION
This is the minimum config for both linting and for trunk.io.

- trunk has it's own hermetic versions of packages
- trunk has actions and can manage git hooks
- trunk has ci tools & dashboards free for public repos 

There is a lot of other linters and config that can be added this is a very good start.